### PR TITLE
Visualize all markers in minmax transform

### DIFF
--- a/templates/minmax_transformer.py
+++ b/templates/minmax_transformer.py
@@ -63,7 +63,7 @@ def collect_and_transform(df, pdfOUT, qTyp, nucMark):
 	pdfOUT.savefig( origVals.get_figure() )
 	
 	
-	colNames = list(filter(lambda x:'Mean' in x, df.columns.tolist()))[0:10]
+	colNames = list(filter(lambda x:'Mean' in x, df.columns.tolist()))
 	NucOnly = list(filter(lambda x:nucMark in x, colNames))[0]
 	for i in range(0, len(colNames), 8):
 		# Create a new figure for each page


### PR DESCRIPTION
Minmax transform script was taking only the first 10 colnames/markers when choosing markers to visualize. Additionally, the script was throwing errors when nucMark was not included in first 10 colnames. Removed indexing so that all channels will be included.