### PR TITLE
Bug fixes

### DIFF
--- a/templates/get_xgboost.py
+++ b/templates/get_xgboost.py
@@ -28,11 +28,11 @@ mim_class_label_threshold = ${params.minimum_label_count}
 
 def make_a_new_model(toTrainDF):
 	allPDFText = {}
-	class_counts = toTrainDF[classColumn].value_counts()
+	#class_counts = toTrainDF[classColumn].value_counts()
 	# Identify classes with fewer than 2 instances
-	classes_to_keep = class_counts[class_counts > mim_class_label_threshold].index
+	#classes_to_keep = class_counts[class_counts > mim_class_label_threshold].index
 	# Filter the dataframe to remove these classes
-	toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
+	#toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
 	X = toTrainDF[list(toTrainDF.select_dtypes(include=[np.number]).columns.values)]
 
 	le = preprocessing.LabelEncoder()

--- a/templates/get_xgboost.py
+++ b/templates/get_xgboost.py
@@ -28,11 +28,6 @@ mim_class_label_threshold = ${params.minimum_label_count}
 
 def make_a_new_model(toTrainDF):
 	allPDFText = {}
-	#class_counts = toTrainDF[classColumn].value_counts()
-	# Identify classes with fewer than 2 instances
-	#classes_to_keep = class_counts[class_counts > mim_class_label_threshold].index
-	# Filter the dataframe to remove these classes
-	#toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
 	X = toTrainDF[list(toTrainDF.select_dtypes(include=[np.number]).columns.values)]
 
 	le = preprocessing.LabelEncoder()

--- a/templates/get_xgboost_winners.py
+++ b/templates/get_xgboost_winners.py
@@ -94,11 +94,6 @@ def plot_parameter_search(df):
 
 def make_a_new_model(toTrainDF):
 	allPDFText = {}
-	class_counts = toTrainDF[classColumn].value_counts()
-	# Identify classes with fewer than 2 instances
-	classes_to_keep = class_counts[class_counts > mim_class_label_threshold].index
-	# Filter the dataframe to remove these classes
-	#toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
 	X = toTrainDF[list(toTrainDF.select_dtypes(include=[np.number]).columns.values)]
 
 	le = preprocessing.LabelEncoder()

--- a/templates/get_xgboost_winners.py
+++ b/templates/get_xgboost_winners.py
@@ -98,7 +98,7 @@ def make_a_new_model(toTrainDF):
 	# Identify classes with fewer than 2 instances
 	classes_to_keep = class_counts[class_counts > mim_class_label_threshold].index
 	# Filter the dataframe to remove these classes
-	toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
+	#toTrainDF = toTrainDF[toTrainDF[classColumn].isin(classes_to_keep)]
 	X = toTrainDF[list(toTrainDF.select_dtypes(include=[np.number]).columns.values)]
 
 	le = preprocessing.LabelEncoder()

--- a/templates/split_annotations_for_training.py
+++ b/templates/split_annotations_for_training.py
@@ -76,6 +76,11 @@ def gather_annotations(pickle_files):
 	merged_df = merged_df.loc[~(merged_df[classColumn].isin(cellTypeNegative))]
 	merged_df = merged_df.reset_index()
 
+	#Remove classes below the threshold
+	class_counts = merged_df[classColumn].value_counts()
+	classes_to_keep = class_counts[class_counts >= minimunHoldoutThreshold].index
+	merged_df = merged_df[merged_df[classColumn].isin(classes_to_keep)]
+
 	ct = merged_df[classColumn].value_counts()
 	pt = merged_df[classColumn].value_counts(normalize=True).mul(100).round(2).astype(str) + '%'
 	

--- a/templates/split_annotations_for_training.py
+++ b/templates/split_annotations_for_training.py
@@ -82,8 +82,9 @@ def gather_annotations(pickle_files):
 
 	#Remove classes below the threshold
 	class_counts = merged_df[classColumn].value_counts()
-	classes_to_keep = class_counts[class_counts >= minimunHoldoutThreshold].index
-	merged_df = merged_df[merged_df[classColumn].isin(classes_to_keep)]
+	classes_to_remove = class_counts[class_counts < minimunHoldoutThreshold].index
+	merged_df = merged_df[~merged_df[classColumn].isin(classes_to_remove)]
+	print("The folloing classes do not have enough labels to model and have been removed from the training and holdout sets: {}".format(classes_to_remove))
 
 	# Get the stratified sample
 	holdoutDF = stratified_sample(merged_df, [batchColumn, classColumn], frac=holdoutFraction, min_count=minimunHoldoutThreshold)

--- a/templates/split_annotations_for_training.py
+++ b/templates/split_annotations_for_training.py
@@ -99,7 +99,7 @@ def gather_annotations(pickle_files):
 		for ln in ctl:
 			f_writer.writerow([ln])
 	# holdoutDF = merged_df.groupby(batchColumn, group_keys=False).apply(lambda x: x.sample(frac=holdoutFraction))
-	trainingDF = merged_df.loc[~merged_df.index.isin(holdoutDF.index)]
+	trainingDF = merged_df.loc[~merged_df["index"].isin(holdoutDF["index"])]
 	trainingDF = trainingDF.reset_index(drop=True)
 
 	holdoutDF.to_pickle('holdout_dataframe.pkl')

--- a/templates/split_annotations_for_training.py
+++ b/templates/split_annotations_for_training.py
@@ -76,14 +76,15 @@ def gather_annotations(pickle_files):
 	merged_df = merged_df.loc[~(merged_df[classColumn].isin(cellTypeNegative))]
 	merged_df = merged_df.reset_index()
 
+	#Get some stats before filtering
+	ct = merged_df[classColumn].value_counts()
+	pt = merged_df[classColumn].value_counts(normalize=True).mul(100).round(2).astype(str) + '%'
+
 	#Remove classes below the threshold
 	class_counts = merged_df[classColumn].value_counts()
 	classes_to_keep = class_counts[class_counts >= minimunHoldoutThreshold].index
 	merged_df = merged_df[merged_df[classColumn].isin(classes_to_keep)]
 
-	ct = merged_df[classColumn].value_counts()
-	pt = merged_df[classColumn].value_counts(normalize=True).mul(100).round(2).astype(str) + '%'
-	
 	# Get the stratified sample
 	holdoutDF = stratified_sample(merged_df, [batchColumn, classColumn], frac=holdoutFraction, min_count=minimunHoldoutThreshold)
 	hd = holdoutDF[classColumn].value_counts()

--- a/templates/split_cell_type_labels.py
+++ b/templates/split_cell_type_labels.py
@@ -24,9 +24,9 @@ def split_and_binarize(df, celltype):
 	## Skip if too few labels exist
 	totCls = df["Lasso_Binary"].sum()
 	print("{} has {} lables".format(celltype, totCls))
-	if totCls < mim_class_label_threshold:
-		print("{} '{}' is not enough class labels to model!".format(totCls, celltype))
-		return 	
+	#if totCls < mim_class_label_threshold:
+	#	print("{} '{}' is not enough class labels to model!".format(totCls, celltype))
+	#	return 	
 	
 	### Add optional parameter to speed up by reducing data amount. Half of target class size
 	if ifSubsetData:


### PR DESCRIPTION
Fixed two bugs in this pull request:

1. Fixed a bug where training set was created using the dataframe index rather than a column named 'index'. After the holdout set is created, the holdoutDF index is reset and it was later being used to subtract from the merged_df to create trainingDF. This resulted in trainingDF having incorrect data and sharing data with the hold out set. This update uses a column called index instead that was created in the original merged_df dataframe
2. Occasionally, specific minimum_label_count values resulted in an error in the holdout training evaluation. Error saying that one of the labels was not previously seen. Fixed error by performing the minimum_label_count filtering early on when creating the holdout/training sets