### PR TITLE
Add plotting feature suffix to call to boxcox_transformer

### DIFF
--- a/modules/normalizations.nf
+++ b/modules/normalizations.nf
@@ -18,7 +18,8 @@ process BOXCOX {
         --batchID ${batchID} \
         --quantType ${params.qupath_object_type} \
         --nucMark ${params.nucleus_marker} \
-        --plotFraction ${params.plot_fraction}
+        --plotFraction ${params.plot_fraction} \
+        --target-feature ${params.plot_target_feature_suffix}
     """
 }
     


### PR DESCRIPTION
The call to the boxcox_transformer script was missing the target-feature flag, which meant that it was using the default "Cell: Mean". This broke on DetectionObjects with the format "Marker: Mean" rather than "Marker: Cell: Mean". I think using the plot_target_feature_suffix parameter fixes this.